### PR TITLE
Allow arbitrary arguments to be passed into casper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Deciding how to visualise this data is the hard part.  It has to be readable and
 ### Options
 
 * createReport (boolean) : Should a report/visualisation be built?
+* casperArgs (string[]): optional arguments to pass into casper and PhantomJS, such as `--ignore-ssl-errors=true`
 * debug (number) : A value of 1 will output more logging, 2 will generate full page screenshots per test which can be found in the test-results folder.  Forces tests onto one thread for readability.
 * earlyexit (boolean) : False by default, if set to true all tests will abort on the first failure
 * includes (string) : Defaults to 'include', it is the root directory of custom global includes (within the PhantomJS domain)

--- a/phantomflow.js
+++ b/phantomflow.js
@@ -55,6 +55,7 @@ module.exports.init = function(options) {
 	var fileGroups;
 
 	var dontDoVisuals = options.skipVisualTests;
+	var casperArgs = options.casperArgs || [];
 
 	var args = [];
 
@@ -174,6 +175,10 @@ module.exports.init = function(options) {
 
 			if(dontDoVisuals){
 				args.push('--novisuals='+dontDoVisuals);
+			}
+
+			if (casperArgs) {
+				args = args.concat(casperArgs);
 			}
 
 			deleteFolderRecursive(results);
@@ -436,7 +441,7 @@ function showReport(dir, port, paths){
 	if(isDir(dir)){
 		console.log("Please use ctrl+c to escape".bold.green);
 		var server = connect(connect.static(dir));
-		
+
 		server.use('/rebase', reqHandler(paths) ).listen(port);
 
 		open('http://localhost:'+port);


### PR DESCRIPTION
Allow custom arguments to be passed into casper, and on to PhantomJS.

(Sorry for duplicate pull request, messed up my branches a little and I couldn't edit the old request)