### PR TITLE
Move hideElements to be an option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Deciding how to visualise this data is the hard part.  It has to be readable and
 * createReport (boolean) : Should a report/visualisation be built?
 * debug (number) : A value of 1 will output more logging, 2 will generate full page screenshots per test which can be found in the test-results folder.  Forces tests onto one thread for readability.
 * earlyexit (boolean) : False by default, if set to true all tests will abort on the first failure
+* hideElements (string[]) : array of element names that should be invisible in the final page, and in screenshots
 * includes (string) : Defaults to 'include', it is the root directory of custom global includes (within the PhantomJS domain)
 * port (number) : Defaults to 9001, this is the port that will be used to show the report/visualisation
 * results (string) : Defaults to 'test-results', it is the root directory of the test results

--- a/lib/phantomCSSAdaptor.js
+++ b/lib/phantomCSSAdaptor.js
@@ -1,7 +1,7 @@
-/* global phantom, require, casper, phantomCSS, phantomFlow, visualTestsRoot */
+/* global phantom, require, casper, phantomCSS, phantomFlow, visualTestsRoot, hideElements, $ */
 
 (function(){
-	
+
 	var fs = require('fs');
 	var currentWhen;
 	var currentDescribe;
@@ -35,7 +35,7 @@
 
 	phantomCSS.init({
 		libraryRoot: phantomCSSRoot,
-		hideElements: 'img, select',
+		hideElements: hideElements,
 		screenshotRoot: visualTestsRoot,
 		comparisonResultRoot: visualResultsRoot,
 		fileNameGetter: fileNameGetter,
@@ -48,14 +48,12 @@
 	});
 
 	phantomCSS.temporarilyEnableImages = function (callback){
-		casper.
-		then(function(){
+		casper.then(function(){
 			casper.evaluate(function(s){ $('img').css('visibility', 'visible'); });
 			phantomCSS.update({hideElements:null});
 			callback();
-		}).
-		then(function(){
-			phantomCSS.update({hideElements:'img,select'});
+		}).then(function(){
+			phantomCSS.update({hideElements: hideElements});
 		});
 	};
 
@@ -66,7 +64,7 @@
 		diffDir =  root + '/' + currentFilename + '/' + currentDescribe;
 		origFile =  diffDir + '/' + currentWhen + increment +'.png';
 		diffFile =  diffDir + '/' + currentWhen + increment +'.diff.png';
-	
+
 		if ( !fs.isDirectory(diffDir) ){
 			fs.makeDirectory(diffDir);
 		}
@@ -92,7 +90,7 @@
 			var when = dir.pop().split('.').shift();
 			var describe = dir.pop();
 			dir = dir.join('/');
-			
+
 			casper.emit('test.report',{
 				suite: dir + '.phantomcss',
 				describe: describe,

--- a/lib/start.js
+++ b/lib/start.js
@@ -20,6 +20,7 @@ var libraryRoot = casper.cli.get('flowlibraryroot') || "";
 var phantomCSSRoot = casper.cli.get('flowphantomcssroot') || "";
 var files = casper.cli.get('flowtests') || "";
 var novisuals = casper.cli.get('novisuals');
+var hideElements = casper.cli.get('hideelements');
 
 var treeOutputRoot =  casper.cli.get('flowoutputroot'); // see phantomFlowAdaptor
 var xUnitOutputRoot =  casper.cli.get('flowxunitoutputroot'); // see xUnit.js

--- a/phantomflow.js
+++ b/phantomflow.js
@@ -55,6 +55,7 @@ module.exports.init = function(options) {
 	var fileGroups;
 
 	var dontDoVisuals = options.skipVisualTests;
+	var hideElements = options.hideElements || [];
 
 	var args = [];
 
@@ -176,9 +177,13 @@ module.exports.init = function(options) {
 				args.push('--novisuals='+dontDoVisuals);
 			}
 
+			if (hideElements) {
+				args.push('--hideelements=' + hideElements.join(','));
+			}
+
 			deleteFolderRecursive(results);
 
-			console.log( 'Parallelising ' + files.length + ' test files on ' + threads + ' threads.\n');
+			console.log('Parallelising ' + files.length + ' test files on ' + threads + ' threads.\n');
 
 			_.forEach(fileGroups, function(files, index){
 


### PR DESCRIPTION
PhantomFlow currently hides all img and select elements from the output, though the documentation makes no mention of this behaviour. I have moved it to be a top-level option instead.

It's possible that the old hidden behaviour should be the default, but I don't know why anyone would want that behaviour, so decided against it.