### PR TITLE
allow for different report output target

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Deciding how to visualise this data is the hard part.  It has to be readable and
 * includes (string) : Defaults to 'include', it is the root directory of custom global includes (within the PhantomJS domain)
 * port (number) : Defaults to 9001, this is the port that will be used to show the report/visualisation
 * results (string) : Defaults to 'test-results', it is the root directory of the test results
+* reports (string) : Defaults to {results} + '/report/', it is the root directory of generated reports, useful for proxying the reports
 * remoteDebug (boolean) : Enable PhantomJS remote debugging
 * remoteDebugAutoStart (boolean) : Enable autostart for PhantomJS remote debugging
 * remoteDebugPort (number) : Defaults to 9000, the port on which Web Inspector will run

--- a/phantomflow.js
+++ b/phantomflow.js
@@ -39,6 +39,7 @@ module.exports.init = function ( options ) {
 	var includes = path.resolve( options.includes || 'include' );
 	var tests = path.resolve( options.tests || 'test' ) + '/';
 	var results = path.resolve( options.results || 'test-results' );
+	var reports = path.resolve( options.reports || results + '/report/' );
 
 	var remoteDebug = options.remoteDebug || false;
 	var remoteDebugAutoStart = options.remoteDebugAutoStart || false;
@@ -65,7 +66,8 @@ module.exports.init = function ( options ) {
 	var dataPath = changeSlashes( results + '/data/' );
 	var xUnitPath = changeSlashes( results + '/xunit/' );
 	var debugPath = changeSlashes( results + '/debug/' );
-	var reportPath = changeSlashes( results + '/report/' );
+	var reportPath = changeSlashes( reports );
+
 	var visualResultsPath = changeSlashes( results + '/visuals/' );
 
 	optionDebug = parseInt( options.debug, 10 ) < 3 ? parseInt( options.debug, 10 ) : void 0;


### PR DESCRIPTION
To be able to proxy the report, it is helpful to redirect output elsewhere.