### PR TITLE
use relative URLs for rebase to be able to proxy reports

### DIFF
--- a/phantomflow.js
+++ b/phantomflow.js
@@ -455,7 +455,7 @@ function showReport( dir, port, paths ) {
 		console.log( "Please use ctrl+c to escape".bold.green );
 		var server = connect( connect.static( dir ) );
 
-		server.use( 'rebase', reqHandler( paths ) ).listen( port );
+		server.use( '/rebase', reqHandler( paths ) ).listen( port );
 
 		open( 'http://localhost:' + port );
 		return false;

--- a/phantomflow.js
+++ b/phantomflow.js
@@ -455,7 +455,7 @@ function showReport( dir, port, paths ) {
 		console.log( "Please use ctrl+c to escape".bold.green );
 		var server = connect( connect.static( dir ) );
 
-		server.use( '/rebase', reqHandler( paths ) ).listen( port );
+		server.use( 'rebase', reqHandler( paths ) ).listen( port );
 
 		open( 'http://localhost:' + port );
 		return false;

--- a/report_templates/Dendrogram/js/main.js
+++ b/report_templates/Dendrogram/js/main.js
@@ -2,7 +2,7 @@
 
 	getDataAndAppendDropdown();
 
-	$.get(window.location.origin+'/rebase')
+	$.get('rebase')
 		.done(function(){
 			initialiseSideBar(true);
 		})
@@ -50,7 +50,7 @@
 
 		rebaseBtn.click(function(){
 			if(confirm("Are you sure you want to accept the latest image as the visual baseline for this test?")){
-				$.post(window.location.origin+'/rebase', {
+				$.post('rebase', {
 					'img': imageToRebase
 				}, function(){
 					rebaseBtn.hide();


### PR DESCRIPTION
To be able to proxy the reports it is necessary not to include the current location (i.e. localhost:{port}) in the AJAX calls.