### PR TITLE
Fix for report generation when specific (not all) test files are run

### DIFF
--- a/phantomflow.js
+++ b/phantomflow.js
@@ -195,7 +195,17 @@ module.exports.init = function ( options ) {
 				args = args.concat( casperArgs );
 			}
 
-			deleteFolderRecursive( results );
+			if ( filterTests ) {
+				deleteFolderRecursive( reportPath );
+				_.forEach( files, function( file ){
+					deleteFolderRecursive( dataPath + file );
+					deleteFolderRecursive( debugPath + file );
+					deleteFolderRecursive( visualResultsPath + file );
+				});
+			}
+			else {
+				deleteFolderRecursive ( results );
+			}
 
 			console.log( 'Parallelising ' + files.length + ' test files on ' + threads + ' threads.\n' );
 


### PR DESCRIPTION
Currently, whenever phantomFlow is run, the results directory is removed. However, this is problematic if instead of running all tests, the user runs a specific test/tests via filterTests variable. In this case, the current report is only generated from the data relating to these tests.

Instead, the visual results/data should be maintained for non-run tests, so that they are included in the newest report. Made adjustments to main script to check if there are filterTests and if so, purge the dataPath, debugPath, and visualResultsPath pertinent only to the test selected.