### PR TITLE
Suppressing verbose logging on single-threaded tests, when optionDebug === 0

### DIFF
--- a/phantomflow.js
+++ b/phantomflow.js
@@ -314,7 +314,7 @@ module.exports.init = function ( options ) {
 
 								child.kill();
 							}
-						} else if ( threads === 1 ) {
+						} else if ( threads === 1 && optionDebug > 0 ) {
 							console.log( line.white );
 						}
 


### PR DESCRIPTION
Currently, when there are multiple threads and debug option is set to zero, all tests run with minimal logging [passes/fails/etc.], however, when only one test is run at a time, the logging is by default very verbose, can be distracting.

Proposed solution, in branch is as follows:
If it is multi-threaded: functions as previously.
If single-threaded, but debug is switched to 0 [or not filled in], then "white line" logs are suppressed, as they are on multi-threaded test runs.

In my setup, users will be almost exclusively running one test flow at a time, so unless we are debugging tests, seeing passes/fails is crucial and not verbose messaging and random line breaks.

If rejected, I would appreciate feedback on what better solution the maintainers/contributors would feel would solve this problem. From my vantage point, having a screen or so worth of feedback [rather than 3+] is appropriate when doing normal automated testing and not debugging new flows.