### PR TITLE
Add a results object to done callback of phantomFlow.run()

### DIFF
--- a/phantomflow.js
+++ b/phantomflow.js
@@ -362,7 +362,7 @@ module.exports.init = function ( options ) {
 				},
 				function () {
 					if ( done ) {
-						done( exitCode );
+						done( exitCode, { passCount: passCount, failCount: failCount, loggedErrors: loggedErrors });
 					}
 				}
 			);


### PR DESCRIPTION
The 'done' function is the callback fired when the flow is finished running. Currently, it only send back an error code. However, with using phantomflow.run() in a scripted situation, some of the information [besides what it logged to stout and the exit code returned] is potential useful.

Therefore, besides issuing the done() callback with the error code, it now issues 'done( errorCode, resultsObject);' This object exposes failCount, passCount, and loggedErrors of the run() closure.