### PR TITLE
Bug fix for 'empty.html' resource errors in debug mode

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -97,7 +97,7 @@ findIncludes( includes );
 
 casper.start( /* 'http://localhost:9001/empty.html' */); // start before all else
 
-casper.thenOpen( emptyPage );
+casper.thenOpen( 'file:///' + emptyPage );
 
 
 /*


### PR DESCRIPTION
PhantomJS 2 requires URLs to have a protocol. This change fixes the resource errors around 'empty.html' described in Huddle/PhantomFlow#46.