### PR TITLE
Removing lines with empty logs and redundant logPrefix lines

### DIFF
--- a/phantomflow.js
+++ b/phantomflow.js
@@ -325,15 +325,18 @@ module.exports.init = function ( options ) {
 					}
 
 					var firstLine = true;
-					bufstr.split( /\n/g ).forEach( function ( line ) {
+					bufstr.split(/\n/g).forEach(function (line) {
+						if (line.trim().length === 0) { // exit if there is an empty log
+							return;
+						}
+                        var originalLine = line;
 							lineDuration = firstLine ? lineDuration : 0;
 							firstLine = false;
 
 						line = child.logPrefix + '(' + lineDuration + 'ms) ' + line;
 
 						if ( /FAIL|\[PhantomCSS\] Screenshot capture failed/.test( line ) ) {
-							log( line.bold.red );
-							errorLog(child.logPrefix + '\n' + line.bold.red);
+							errorLog('\n' + line.bold.red);
 							child.numFails++;
 
 							loggedErrors.push( {
@@ -351,18 +354,21 @@ module.exports.init = function ( options ) {
 						} else if ( /PASS/.test( line ) ) {
 							passCount++;
 							child.numPasses++;
-							log( line.green );
+							log('\n' + line.green );
 						} else if ( /DEBUG/.test( line ) ) {
 							log( ( '\n' + line.replace( /DEBUG/, '' ) + '\n' ).yellow );
 						} else if ( child.hasErrored ) {
-							log( line.bold.red );
-							errorLog(child.logPrefix + '\n  '+line.bold.red +'\n');
+							errorLog('\n  '+line.bold.red);
 							if ( earlyExit === true ) {
 								writeLog( results, child.failFileName, child.stdoutStr, log );
 								child.kill();
 							}
-						} else if ( numProcesses === 1 && optionDebug > 0 ) {
-							log( line.white );
+						} else if (numProcesses === 1 && optionDebug > 0) {
+							if (originalLine[0] === '#') { //if there is a casper detail message
+									log(line.red)
+								} else {
+									log('\n' + line.white);
+								}
 						}
 
 						child.stdoutStr += line;


### PR DESCRIPTION
Logging post 0.5.12 added some helpful items such as the addition of the timelapse and file name. 
However, it also seemed to add duplicate lines of logging when running phantom flow mode with the debug mode turned on.
![97a15efc-12df-11e6-84d3-9b88203d5639](https://cloud.githubusercontent.com/assets/1932544/15075744/9f875446-136b-11e6-9d17-b6c99bb9f56f.png)

Now this screenshot is [without the fix](https://github.com/Huddle/PhantomFlow/pull/47) that Emily Skitek submitted for the resource errors in debug mode

With that fix in place the logging is still extra verbose, it just doesn't color everything red anymore.

This modification to the logs that I made will also group the casper related errors underneath the failure so it is more easily readable
![caspererror](https://cloud.githubusercontent.com/assets/1932544/15075941/baf58b20-136c-11e6-9254-e72036e21c62.PNG)

The modification also removes blank lines of logs to reduce wasted space.
