### PR TITLE
Make debug event listeners removable

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -59,17 +59,20 @@ casper.on( 'page.error', function( msg, trace ) {
 });
 
 if( debug >= 1 ) {
-    casper.on( 'remote.message', function( msg ) {
+    onRemoteMessage = function( msg ) {
         this.echo( 'Log: ' + JSON.stringify( msg ) );
-    });
+    }
+    casper.on( 'remote.message', onRemoteMessage);
 
-    casper.on( 'resource.error', function( resourceError ){
+    onResourceError = function( resourceError ){
        this.echo( 'Resource Error: ' + JSON.stringify( resourceError, null, 2 ), 'ERROR');
-    });
+    }
+    casper.on( 'resource.error', onResourceError);
 
-    casper.on( 'url.changed', function( newUrl ){
+    onUrlChanged = function( newUrl ){
         this.echo( 'URL Changed:' + JSON.stringify( newUrl ) );
-    });
+    }
+    casper.on( 'url.changed', onUrlChanged);
 }
 
 /*


### PR DESCRIPTION
Factor debug event listener closure functions into named functions so they can be removed using casper.removeListener() if needed.

In my case I want to suppress "Resource Error" debug logs which occur every time a page location changes while image resource haven't finished loading yet.
