### PR TITLE
Enquote path args to handle paths with spaces.

### DIFF
--- a/phantomflow.js
+++ b/phantomflow.js
@@ -186,17 +186,17 @@ module.exports.init = function ( options ) {
 			 Setup arguments to be sent into PhantomJS
 			 */
 
-			args.push( changeSlashes( path.join( bootstrapPath, 'start.js' ) ) );
-			args.push( '--flowincludes=' + changeSlashes( includes ) );
-			args.push( '--flowtestsroot=' + changeSlashes( tests ) );
-			args.push( '--flowphantomcssroot=' + changeSlashes(path.dirname(require.resolve( 'phantomcss' )) ));
-			args.push( '--flowlibraryroot=' + changeSlashes( bootstrapPath ) );
-			args.push( '--flowoutputroot=' + changeSlashes( dataPath ) );
-			args.push( '--flowcoverageroot=' + changeSlashes( coveragePath ) );
-			args.push( '--flowxunitoutputroot=' + changeSlashes( xUnitPath ) );
-			args.push( '--flowvisualdebugroot=' + changeSlashes( debugPath ) );
-			args.push( '--flowvisualstestroot=' + changeSlashes( visualTestsPath ) );
-			args.push( '--flowvisualsoutputroot=' + changeSlashes( visualResultsPath ) );
+			args.push( '"' + changeSlashes( path.join( bootstrapPath, 'start.js' ) ) + '"' );
+			args.push( '--flowincludes="' + changeSlashes( includes ) + '"' );
+			args.push( '--flowtestsroot="' + changeSlashes( tests ) + '"' );
+			args.push( '--flowphantomcssroot="' + changeSlashes(path.dirname(require.resolve( 'phantomcss' )) ) + '"' );
+			args.push( '--flowlibraryroot="' + changeSlashes( bootstrapPath ) + '"' );
+			args.push( '--flowoutputroot="' + changeSlashes( dataPath ) + '"' );
+			args.push( '--flowcoverageroot="' + changeSlashes( coveragePath ) + '"' );
+			args.push( '--flowxunitoutputroot="' + changeSlashes( xUnitPath ) + '"' );
+			args.push( '--flowvisualdebugroot="' + changeSlashes( debugPath ) + '"' );
+			args.push( '--flowvisualstestroot="' + changeSlashes( visualTestsPath ) + '"' );
+			args.push( '--flowvisualsoutputroot="' + changeSlashes( visualResultsPath ) + '"' );
 
 			if ( optionDebug !== void 0 ) {
 				args.push( '--flowdebug=' + optionDebug );


### PR DESCRIPTION
Prior to this change, running tests from a path that contains spaces produces output like this:

```
Parallelising 2 test files on 2 processes.

Picking up job: example1.test.js
Picking up job: example2.test.js
[example1.test.js] It broke, sorry. Process aborted. Non-zero code (1) returned.
[example1.test.js] It broke, sorry. Process aborted. Non-zero code (1) returned.

 Please take a look at the error log for more info 'C:\Example Directory\Tests\test-results/log/error_1.log'
[example2.test.js] It broke, sorry. Process aborted. Non-zero code (1) returned.
[example2.test.js] It broke, sorry. Process aborted. Non-zero code (1) returned.

 Please take a look at the error log for more info 'C:\Example Directory\Tests\test-results/log/error_2.log'
```

error_1.log contains:

```
[example1.test.js] (1788ms) Unable to open file: C:/Example
[example1.test.js] (0ms)   phantomjs://code/bootstrap.js:110 in __die
[example1.test.js] (0ms) Unable to load script C:/Example; check file syntax
[example1.test.js] (0ms)   phantomjs://code/bootstrap.js:110 in __die
```