### PR TITLE
#56 Don't quote args for Unix-based OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomflow",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "UI testing with PhantomCSS and Decision Trees",
   "main": "phantomflow.js",
   "repository": {

--- a/phantomflow.js
+++ b/phantomflow.js
@@ -116,6 +116,11 @@ module.exports.init = function ( options ) {
 		return;
 	}
 
+	function quoteItForWindows(str) {
+		var isWindows = /^win/.test(process.platform);
+		return isWindows ? '"' + str + '"' : str;
+	}
+
 	if (options.dashboard && options.createReport) {
 		dashboardLogger.report = report;
 	}
@@ -193,17 +198,18 @@ module.exports.init = function ( options ) {
 			 Setup arguments to be sent into PhantomJS
 			 */
 
-			args.push( '"' + changeSlashes( path.join( bootstrapPath, 'start.js' ) ) + '"' );
-			args.push( '--flowincludes="' + changeSlashes( includes ) + '"' );
-			args.push( '--flowtestsroot="' + changeSlashes( tests ) + '"' );
-			args.push( '--flowphantomcssroot="' + changeSlashes(path.dirname(require.resolve( 'phantomcss' )) ) + '"' );
-			args.push( '--flowlibraryroot="' + changeSlashes( bootstrapPath ) + '"' );
-			args.push( '--flowoutputroot="' + changeSlashes( dataPath ) + '"' );
-			args.push( '--flowcoverageroot="' + changeSlashes( coveragePath ) + '"' );
-			args.push( '--flowxunitoutputroot="' + changeSlashes( xUnitPath ) + '"' );
-			args.push( '--flowvisualdebugroot="' + changeSlashes( debugPath ) + '"' );
-			args.push( '--flowvisualstestroot="' + changeSlashes( visualTestsPath ) + '"' );
-			args.push( '--flowvisualsoutputroot="' + changeSlashes( visualResultsPath ) + '"' );
+			args.push(  quoteItForWindows(changeSlashes( path.join( bootstrapPath, 'start.js' ) ) ) );
+			args.push( '--flowincludes=' + quoteItForWindows(changeSlashes( includes ) ) );
+			args.push( '--flowtestsroot=' + quoteItForWindows(changeSlashes( tests ))  );
+			args.push( '--flowphantomcssroot=' + quoteItForWindows(changeSlashes(path.dirname(require.resolve( 'phantomcss' )) ) ) );
+			args.push( '--flowlibraryroot=' + quoteItForWindows(changeSlashes( bootstrapPath ) ) );
+			args.push( '--flowoutputroot=' + quoteItForWindows(changeSlashes( dataPath ) ) );
+			args.push( '--flowcoverageroot=' + quoteItForWindows(changeSlashes( coveragePath )) );
+			args.push( '--flowxunitoutputroot=' + quoteItForWindows(changeSlashes( xUnitPath ) ));
+			args.push( '--flowxunitoutputroot=' + quoteItForWindows(changeSlashes( xUnitPath )) );
+			args.push( '--flowvisualdebugroot=' + quoteItForWindows(changeSlashes( debugPath ) ) );
+			args.push( '--flowvisualstestroot=' + quoteItForWindows(changeSlashes( visualTestsPath ) ) );
+			args.push( '--flowvisualsoutputroot=' + quoteItForWindows(changeSlashes( visualResultsPath ) ) );
 
 			if ( optionDebug !== void 0 ) {
 				args.push( '--flowdebug=' + optionDebug );


### PR DESCRIPTION
Fixed https://github.com/Huddle/PhantomFlow/issues/56. This issue was caused by the addition of quotes to the CasperJS arguments (https://github.com/Huddle/PhantomFlow/pull/54), and affected Unix based systems like OSX. To be safe, we now only add quotes for Windows environments.